### PR TITLE
Link matching Google email accounts

### DIFF
--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -9,9 +9,10 @@ import {
   signInWithPopup,
   signInWithRedirect,
   signOut,
+  linkWithPopup,
   type User,
 } from "firebase/auth";
-import { doc, getDoc, setDoc, updateDoc, arrayUnion, serverTimestamp } from "firebase/firestore";
+import { arrayUnion, collection, doc, getDoc, getDocs, query, serverTimestamp, setDoc, updateDoc, where } from "firebase/firestore";
 import { auth, createGoogleProvider, db } from "./firebase";
 
 // ─── useAuth ────────────────────────────────────────────────────
@@ -24,14 +25,50 @@ export function useAuth() {
     const userDoc = await getDoc(userRef);
 
     if (!userDoc.exists()) {
-      await setDoc(userRef, {
+      const fallbackProfile = {
         name: firebaseUser.displayName || firebaseUser.email?.split("@")[0] || "User",
         email: firebaseUser.email,
         birthDate: null,
         avatar: "👤",
         houseId: null,
         createdAt: serverTimestamp(),
-      });
+      };
+
+      if (firebaseUser.email) {
+        const matchingUsers = await getDocs(query(collection(db, "users"), where("email", "==", firebaseUser.email)));
+        const existingUser = matchingUsers.docs.find((snap) => snap.id !== firebaseUser.uid);
+
+        if (existingUser) {
+          const existingProfile = existingUser.data();
+          await setDoc(userRef, {
+            ...fallbackProfile,
+            ...existingProfile,
+            email: firebaseUser.email,
+            linkedUid: existingUser.id,
+            linkedAt: serverTimestamp(),
+          });
+
+          if (typeof existingProfile.houseId === "string") {
+            const houseRef = doc(db, "houses", existingProfile.houseId);
+            const houseSnap = await getDoc(houseRef);
+            if (houseSnap.exists()) {
+              const members = houseSnap.data().members;
+              if (Array.isArray(members)) {
+                await updateDoc(houseRef, {
+                  members: members.map((member) =>
+                    member && typeof member === "object" && "uid" in member && member.uid === existingUser.id
+                      ? { ...member, uid: firebaseUser.uid }
+                      : member,
+                  ),
+                });
+              }
+            }
+          }
+          return;
+        }
+      }
+
+      await setDoc(userRef, fallbackProfile);
       return;
     }
 
@@ -76,13 +113,33 @@ export function useAuth() {
 
   const loginWithGoogle = async () => {
     const provider = createGoogleProvider();
+    const currentUser = auth.currentUser;
 
     try {
+      if (currentUser?.email) {
+        const cred = await linkWithPopup(currentUser, provider);
+        await ensureUserDoc(cred.user);
+        return cred;
+      }
+
       const cred = await signInWithPopup(auth, provider);
       await ensureUserDoc(cred.user);
       return cred;
     } catch (error) {
       const code = typeof error === "object" && error !== null && "code" in error ? String(error.code) : "";
+      const linkedEmail =
+        typeof error === "object" &&
+        error !== null &&
+        "customData" in error &&
+        typeof error.customData === "object" &&
+        error.customData !== null &&
+        "email" in error.customData
+          ? String(error.customData.email)
+          : null;
+
+      if (currentUser?.email && linkedEmail && currentUser.email.toLowerCase() !== linkedEmail.toLowerCase()) {
+        throw new Error("A conta Google selecionada usa um email diferente da conta atual.");
+      }
 
       if (code === "auth/popup-blocked" || code === "auth/popup-closed-by-user" || code === "auth/cancelled-popup-request") {
         await signInWithRedirect(auth, provider);


### PR DESCRIPTION
### Motivation

- Prevent duplicate user records when a Google sign-in creates a new Firebase UID for an email that already exists in Firestore.  
- Allow an already-signed-in email/password user to link their account to Google so users can add Google auth without creating separate identities.

### Description

- Update `lib/auth.ts` to add `linkWithPopup` and additional Firestore helpers and change `ensureUserDoc` to build a `fallbackProfile` when a Firebase user doc is missing.  
- When a new Google-authenticated UID has no user document but a Firestore user exists with the same email, copy the existing profile to the Google UID and add `linkedUid` and `linkedAt` metadata.  
- If the existing profile belongs to a house, update the house's `members` array to replace the old member `uid` with the Google-authenticated `uid` so membership continues to work.  
- In `loginWithGoogle` use `linkWithPopup` when there is a currently signed-in user to attach Google credentials, and validate `customData.email` on errors to avoid linking a different email account; preserve the existing redirect fallback for popup-blocked cases.

### Testing

- Ran static typecheck with `npm run typecheck` and it completed successfully.  
- Ran lint with `npm run lint` which passed with only pre-existing warnings.  
- Ran unit tests with `npm test -- --runInBand` and all tests passed (`2` test suites, `42` tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a43c629fe8c83299d697d4c0985d101)