### PR TITLE
Fix Firebase Google auth configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,8 @@ NEXT_PUBLIC_FIREBASE_APP_ID=your_app_id
 1. Create project in [Firebase Console](https://console.firebase.google.com)
 2. Enable Firestore Database
 3. Enable Authentication → Email/Password + Google
-4. (Optional) Enable Cloud Messaging for push notifications
+4. In Authentication → Settings → Authorized domains, add every domain that will serve the app (for example `localhost`, your Vercel preview/production domains, and any custom domain)
+5. (Optional) Enable Cloud Messaging for push notifications
 
 ### 4. Run locally
 

--- a/lib/firebase.ts
+++ b/lib/firebase.ts
@@ -4,12 +4,12 @@ import { getAuth, GoogleAuthProvider } from "firebase/auth";
 import { getMessaging, getToken, isSupported, onMessage, type Messaging } from "firebase/messaging";
 
 const firebaseConfig = {
-  apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY || "demo-api-key",
-  authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN || "demo-project.firebaseapp.com",
-  projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID || "demo-project",
-  storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET || "demo-project.appspot.com",
-  messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID || "000000000000",
-  appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID || "1:000000000000:web:0000000000000000000000",
+  apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY || "AIzaSyDFijQyeFuPj4L2sjrojXaMf4yBoMvApho",
+  authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN || "casa-66668.firebaseapp.com",
+  projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID || "casa-66668",
+  storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET || "casa-66668.firebasestorage.app",
+  messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID || "776757654663",
+  appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID || "1:776757654663:web:15c0fa42ae1815d43ff422",
 };
 
 const app = getApps().length === 0 ? initializeApp(firebaseConfig) : getApps()[0];


### PR DESCRIPTION
### Motivation
- Prevent Google sign-in from initializing against a placeholder auth domain when environment variables are missing by using the app's real Firebase project values as fallbacks.
- Make the README explicit about adding all served domains to Firebase Authentication authorized domains to avoid `unauthorized-domain` errors.

### Description
- Update `lib/firebase.ts` to replace demo fallback values with the project's Firebase values (e.g. `casa-66668.firebaseapp.com`) so the client initializes against the correct `authDomain` when env vars are absent.
- Update `README.md` to document that every domain serving the app must be added in Firebase Console → Authentication → Settings → Authorized domains.

### Testing
- Ran `npm run typecheck` and it completed successfully.
- Ran `npm run lint` which completed (existing warnings remain but no new errors).
- Ran `npm test -- --runInBand` and all test suites passed (2/2).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a43c5ef0bbc8329bbcd7877229435b8)