### PR TITLE
Add Google account linking, normalize emails, and improve user/profile recovery

### DIFF
--- a/app/convite/[code]/page.tsx
+++ b/app/convite/[code]/page.tsx
@@ -105,7 +105,7 @@ export default function InvitePage() {
         <AuthScreen
           onLogin={async (email, pw) => { await login(email, pw); }}
           onRegister={async (name, email, pw) => { await register(name, email, pw); }}
-          onGoogle={async () => { await loginWithGoogle(); }}
+          onGoogle={async (_email, pw) => { await loginWithGoogle(pw); }}
         />
       </div>
     );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -64,7 +64,7 @@ function HomeInner() {
       <AuthScreen
         onLogin={async (email, pw) => { await login(email, pw); }}
         onRegister={async (name, email, pw, birthDate) => { await register(name, email, pw, birthDate); setUserName(name); }}
-        onGoogle={async () => { await loginWithGoogle(); }}
+        onGoogle={async (_email, pw) => { await loginWithGoogle(pw); }}
       />
     );
   }

--- a/components/AuthScreen.tsx
+++ b/components/AuthScreen.tsx
@@ -6,7 +6,7 @@ import { useT } from "@/lib/i18n";
 interface AuthScreenProps {
   onLogin: (email: string, password: string) => Promise<void>;
   onRegister: (name: string, email: string, password: string, birthDate: string) => Promise<void>;
-  onGoogle: () => Promise<void>;
+  onGoogle: (email: string, password: string) => Promise<void>;
 }
 
 export default function AuthScreen({ onLogin, onRegister, onGoogle }: AuthScreenProps) {
@@ -152,7 +152,7 @@ export default function AuthScreen({ onLogin, onRegister, onGoogle }: AuthScreen
             setError("");
             setLoading(true);
             try {
-              await onGoogle();
+              await onGoogle(email, password);
             } catch (e: unknown) {
               const msg = e instanceof Error ? e.message : "Erro desconhecido";
               if (msg.includes("unauthorized-domain")) setError("Domínio não autorizado no Firebase Authentication");

--- a/components/ProfilePage.tsx
+++ b/components/ProfilePage.tsx
@@ -41,7 +41,7 @@ export default function ProfilePage({ onClose, viewMember }: ProfilePageProps) {
   const [boxesOpened, setBoxesOpened] = useState(0);
   const [loading, setLoading] = useState(true);
   const [activeTab, setActiveTab] = useState<"stats" | "inventory" | "avatar" | "settings">("stats");
-  const { user } = useAuth();
+  const { user, linkGoogleAccount } = useAuth();
   const { houseId } = useHouseContext();
 
   useEffect(() => {
@@ -201,7 +201,7 @@ export default function ProfilePage({ onClose, viewMember }: ProfilePageProps) {
       ) : activeTab === "avatar" ? (
         <AvatarBuilder owner={user?.displayName || user?.email || "user"} onSave={(config) => setAvatarConfig(config)} />
       ) : (
-        <SettingsTab user={user} houseId={houseId} />
+        <SettingsTab user={user} houseId={houseId} onLinkGoogle={linkGoogleAccount} />
       )}
     </div>
   );
@@ -376,7 +376,7 @@ function StatsTab({ stats, rpgStats, currentBadges }: { stats: GameStats; rpgSta
 
 // ─── Settings Tab ──────────────────────────────────────────────
 
-function SettingsTab({ user, houseId }: { user: User | null; houseId: string }) {
+function SettingsTab({ user, houseId, onLinkGoogle }: { user: User | null; houseId: string; onLinkGoogle: () => Promise<unknown> }) {
   const [displayName, setDisplayName] = useState(user?.displayName || "");
   const [newEmail, setNewEmail] = useState(user?.email || "");
   const [newPassword, setNewPassword] = useState("");
@@ -443,6 +443,21 @@ function SettingsTab({ user, houseId }: { user: User | null; houseId: string }) 
       setTimeout(() => setStatus(null), 3000);
     } catch (e) {
       setStatus(`❌ Erro: ${e}`);
+    }
+    setSaving(false);
+  };
+
+
+  const handleLinkGoogle = async () => {
+    if (!user) return;
+    setSaving(true);
+    try {
+      await onLinkGoogle();
+      setStatus("✨ Google ligado à tua conta!");
+      setTimeout(() => setStatus(null), 3000);
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      setStatus(`❌ Erro: ${message}`);
     }
     setSaving(false);
   };
@@ -539,6 +554,22 @@ function SettingsTab({ user, houseId }: { user: User | null; houseId: string }) 
             Alterar password
           </button>
         </div>
+      </div>
+
+
+      {/* Google linking */}
+      <div className="pt-2 border-t border-purple-200/40">
+        <h3 className="text-xs font-bold text-purple-600 uppercase tracking-wider mb-2">Google</h3>
+        <button
+          onClick={handleLinkGoogle}
+          disabled={saving || user?.providerData.some((providerData) => providerData.providerId === "google.com")}
+          className="w-full rounded-xl bg-white/80 border border-purple-200/40 py-2.5 text-sm font-medium text-rose-600 hover:bg-pink-50 disabled:opacity-40 transition-all active:scale-95"
+        >
+          {user?.providerData.some((providerData) => providerData.providerId === "google.com") ? "Google já ligado" : "Ligar Google a esta conta"}
+        </button>
+        <p className="mt-2 text-[11px] text-purple-500 text-center">
+          Entra com email/password primeiro e liga Google aqui para manter a mesma casa e dados.
+        </p>
       </div>
 
       {/* Status message */}

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -10,6 +10,7 @@ import {
   signInWithRedirect,
   signOut,
   linkWithPopup,
+  fetchSignInMethodsForEmail,
   type User,
 } from "firebase/auth";
 import { arrayUnion, collection, doc, getDoc, getDocs, query, serverTimestamp, setDoc, updateDoc, where } from "firebase/firestore";
@@ -27,23 +28,28 @@ export function useAuth() {
     if (!userDoc.exists()) {
       const fallbackProfile = {
         name: firebaseUser.displayName || firebaseUser.email?.split("@")[0] || "User",
-        email: firebaseUser.email,
+        email: firebaseUser.email?.toLowerCase() || null,
         birthDate: null,
         avatar: "👤",
-        houseId: null,
+        houseId: null as string | null,
         createdAt: serverTimestamp(),
       };
 
       if (firebaseUser.email) {
-        const matchingUsers = await getDocs(query(collection(db, "users"), where("email", "==", firebaseUser.email)));
-        const existingUser = matchingUsers.docs.find((snap) => snap.id !== firebaseUser.uid);
+        const normalizedEmail = firebaseUser.email.toLowerCase();
+        const matchingUsers = await getDocs(query(collection(db, "users"), where("email", "==", normalizedEmail)));
+        const legacyMatchingUsers =
+          normalizedEmail === firebaseUser.email
+            ? { docs: [] }
+            : await getDocs(query(collection(db, "users"), where("email", "==", firebaseUser.email)));
+        const existingUser = [...matchingUsers.docs, ...legacyMatchingUsers.docs].find((snap) => snap.id !== firebaseUser.uid);
 
         if (existingUser) {
           const existingProfile = existingUser.data();
           await setDoc(userRef, {
             ...fallbackProfile,
             ...existingProfile,
-            email: firebaseUser.email,
+            email: firebaseUser.email.toLowerCase(),
             linkedUid: existingUser.id,
             linkedAt: serverTimestamp(),
           });
@@ -68,6 +74,23 @@ export function useAuth() {
         }
       }
 
+      const housesSnap = await getDocs(collection(db, "houses"));
+      for (const house of housesSnap.docs) {
+        const members = house.data().members;
+        if (!Array.isArray(members)) continue;
+
+        const member = members.find(
+          (item) => item && typeof item === "object" && "uid" in item && item.uid === firebaseUser.uid,
+        );
+        if (member && typeof member === "object") {
+          fallbackProfile.houseId = house.id;
+          if ("name" in member && typeof member.name === "string" && member.name.trim()) {
+            fallbackProfile.name = member.name;
+          }
+          break;
+        }
+      }
+
       await setDoc(userRef, fallbackProfile);
       return;
     }
@@ -87,14 +110,28 @@ export function useAuth() {
       });
 
     const unsub = onAuthStateChanged(auth, (u) => {
-      setUser(u);
-      setLoading(false);
+      if (!u) {
+        setUser(null);
+        setLoading(false);
+        return;
+      }
+
+      ensureUserDoc(u)
+        .catch((error) => {
+          console.error("User profile recovery error:", error);
+        })
+        .finally(() => {
+          setUser(u);
+          setLoading(false);
+        });
     });
     return () => unsub();
   }, [ensureUserDoc]);
 
   const login = async (email: string, password: string) => {
-    return signInWithEmailAndPassword(auth, email, password);
+    const cred = await signInWithEmailAndPassword(auth, email, password);
+    await ensureUserDoc(cred.user);
+    return cred;
   };
 
   const register = async (name: string, email: string, password: string, birthDate?: string) => {
@@ -102,7 +139,7 @@ export function useAuth() {
     // Create user doc
     await setDoc(doc(db, "users", cred.user.uid), {
       name,
-      email,
+      email: email.toLowerCase(),
       birthDate: birthDate || null,
       avatar: "👤",
       houseId: null,
@@ -117,6 +154,11 @@ export function useAuth() {
 
     try {
       if (currentUser?.email) {
+        if (currentUser.providerData.some((providerData) => providerData.providerId === "google.com")) {
+          await ensureUserDoc(currentUser);
+          return null;
+        }
+
         const cred = await linkWithPopup(currentUser, provider);
         await ensureUserDoc(cred.user);
         return cred;
@@ -141,6 +183,23 @@ export function useAuth() {
         throw new Error("A conta Google selecionada usa um email diferente da conta atual.");
       }
 
+      if (code === "auth/account-exists-with-different-credential" && linkedEmail) {
+        const methods = await fetchSignInMethodsForEmail(auth, linkedEmail);
+        if (methods.includes("password")) {
+          throw new Error("Esta conta já existe com email/password. Entra primeiro com email/password e depois carrega no botão Google para ligar o Google sem perder os dados.");
+        }
+        throw new Error("Esta conta já existe com outro método de login. Entra primeiro com esse método e depois liga o Google no botão Google.");
+      }
+
+      if (code === "auth/provider-already-linked") {
+        if (currentUser) await ensureUserDoc(currentUser);
+        return null;
+      }
+
+      if (code === "auth/credential-already-in-use" || code === "auth/email-already-in-use") {
+        throw new Error("Esta conta Google já está ligada a outra sessão. Sai da conta atual e entra diretamente com Google.");
+      }
+
       if (code === "auth/popup-blocked" || code === "auth/popup-closed-by-user" || code === "auth/cancelled-popup-request") {
         await signInWithRedirect(auth, provider);
         return null;
@@ -152,7 +211,7 @@ export function useAuth() {
 
   const logout = () => signOut(auth);
 
-  return { user, loading, login, register, loginWithGoogle, logout };
+  return { user, loading, login, register, loginWithGoogle, linkGoogleAccount: loginWithGoogle, logout };
 }
 
 // ─── Birth date migration for existing users ────────────────────
@@ -186,8 +245,16 @@ export function useHouse(uid: string | null) {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    if (!uid) { setLoading(false); return; } // eslint-disable-line react-hooks/set-state-in-effect
+    if (!uid) {
+      setHouseId(null);
+      setHouse(null);
+      setLoading(false);
+      return;
+    }
 
+    setHouseId(null);
+    setHouse(null);
+    setLoading(true);
     let unsubHouse: (() => void) | null = null;
 
     const load = async () => {

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -10,7 +10,9 @@ import {
   signInWithRedirect,
   signOut,
   linkWithPopup,
+  linkWithCredential,
   fetchSignInMethodsForEmail,
+  GoogleAuthProvider,
   type User,
 } from "firebase/auth";
 import { arrayUnion, collection, doc, getDoc, getDocs, query, serverTimestamp, setDoc, updateDoc, where } from "firebase/firestore";
@@ -148,7 +150,7 @@ export function useAuth() {
     return cred;
   };
 
-  const loginWithGoogle = async () => {
+  const loginWithGoogle = async (passwordForExistingAccount?: string) => {
     const provider = createGoogleProvider();
     const currentUser = auth.currentUser;
 
@@ -185,10 +187,23 @@ export function useAuth() {
 
       if (code === "auth/account-exists-with-different-credential" && linkedEmail) {
         const methods = await fetchSignInMethodsForEmail(auth, linkedEmail);
-        if (methods.includes("password")) {
-          throw new Error("Esta conta já existe com email/password. Entra primeiro com email/password e depois carrega no botão Google para ligar o Google sem perder os dados.");
+        const googleCredential = GoogleAuthProvider.credentialFromError(error as Parameters<typeof GoogleAuthProvider.credentialFromError>[0]);
+
+        if (methods.includes("password") && googleCredential) {
+          if (!passwordForExistingAccount) {
+            throw new Error("Esta conta já existe com email/password. Escreve a password dessa conta e carrega novamente no botão Google para ligar o Google sem perder os dados.");
+          }
+
+          const cred = await signInWithEmailAndPassword(auth, linkedEmail, passwordForExistingAccount);
+          await linkWithCredential(cred.user, googleCredential);
+          await ensureUserDoc(cred.user);
+          return cred;
         }
-        throw new Error("Esta conta já existe com outro método de login. Entra primeiro com esse método e depois liga o Google no botão Google.");
+
+        if (methods.includes("password")) {
+          throw new Error("Esta conta já existe com email/password. Entra primeiro com email/password e depois liga Google em Perfil → Google.");
+        }
+        throw new Error("Esta conta já existe com outro método de login. Entra primeiro com esse método e depois liga Google em Perfil → Google.");
       }
 
       if (code === "auth/provider-already-linked") {
@@ -211,7 +226,9 @@ export function useAuth() {
 
   const logout = () => signOut(auth);
 
-  return { user, loading, login, register, loginWithGoogle, linkGoogleAccount: loginWithGoogle, logout };
+  const linkGoogleAccount = () => loginWithGoogle();
+
+  return { user, loading, login, register, loginWithGoogle, linkGoogleAccount, logout };
 }
 
 // ─── Birth date migration for existing users ────────────────────


### PR DESCRIPTION
### Motivation
- Add a way for users to link a Google account from the Settings UI without losing existing account data and to surface helpful errors when linking fails.
- Ensure consistent email normalization and robust recovery/merging of legacy user documents when users sign in with different providers.
- Improve detection of house membership for recovered users and ensure user docs are created/updated on sign-in flows.

### Description
- Exposed Google linking from `useAuth` by returning `linkGoogleAccount: loginWithGoogle` and enhanced `loginWithGoogle` to handle many linking edge-cases including `auth/account-exists-with-different-credential`, `auth/provider-already-linked`, and `auth/credential-already-in-use`, and to fall back to redirect for popup issues; added use of `fetchSignInMethodsForEmail` to inspect existing sign-in methods.
- Normalized emails to lowercase in `ensureUserDoc`, `register`, and when creating/merging user documents, and merged legacy documents by checking both normalized and raw emails to avoid duplicate accounts.
- Improved profile recovery by searching `houses` to infer `houseId` and member `name` for users that already exist in house member arrays, and ensured `ensureUserDoc` is awaited before setting the `user` state in the auth listener.
- Updated `useHouse` to reset state consistently when `uid` is null and to set loading flags correctly while loading house data.
- Wired the Settings UI in `components/ProfilePage.tsx` to accept a new `onLinkGoogle` prop and added a Google linking section with `handleLinkGoogle` to trigger linking and display status messages.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a43cd5b2e448329814e5064ed664e14)