### PR TITLE
Fix Firebase event share data access

### DIFF
--- a/app/eventos/[shareId]/page.tsx
+++ b/app/eventos/[shareId]/page.tsx
@@ -3,17 +3,18 @@
 import { useState, useEffect } from "react";
 import { useParams } from "next/navigation";
 import EventList from "@/components/EventList";
-import { validateShareId } from "@/lib/share";
+import { getEventShare, type EventShare } from "@/lib/share";
+import { HouseIdContext } from "@/lib/hooks";
 
 export default function PublicEventsPage() {
   const params = useParams();
   const shareId = params.shareId as string;
-  const [valid, setValid] = useState<boolean | null>(null);
+  const [share, setShare] = useState<EventShare | null | undefined>(undefined);
   const [guestName, setGuestName] = useState<string | null>(null);
   const [nameInput, setNameInput] = useState("");
 
   useEffect(() => {
-    validateShareId(shareId).then(setValid);
+    getEventShare(shareId).then(setShare);
     const saved = localStorage.getItem("casa-guest-name");
     if (saved) setGuestName(saved); // eslint-disable-line react-hooks/set-state-in-effect
   }, [shareId]);
@@ -25,7 +26,7 @@ export default function PublicEventsPage() {
     setGuestName(name);
   };
 
-  if (valid === null) {
+  if (share === undefined) {
     return (
       <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-purple-50 via-pink-50 to-rose-50">
         <div className="text-3xl animate-pulse">🎉</div>
@@ -33,7 +34,7 @@ export default function PublicEventsPage() {
     );
   }
 
-  if (!valid) {
+  if (!share) {
     return (
       <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-purple-50 via-pink-50 to-rose-50">
         <div className="text-center space-y-3">
@@ -98,7 +99,9 @@ export default function PublicEventsPage() {
 
       {/* Events */}
       <main className="flex-1">
-        <EventList isPublic guestName={guestName} />
+        <HouseIdContext.Provider value={share.houseId}>
+          <EventList isPublic guestName={guestName} />
+        </HouseIdContext.Provider>
       </main>
     </div>
   );

--- a/components/EventList.tsx
+++ b/components/EventList.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useContext } from "react";
 import TabTip from "@/components/TabTip";
-import { useCollection } from "@/lib/hooks";
+import { HouseIdContext, useCollection } from "@/lib/hooks";
 import { getOrCreateShareId } from "@/lib/share";
 import { collection, getDocs } from "firebase/firestore";
 import { db } from "@/lib/firebase";
@@ -85,9 +85,10 @@ interface EventListProps {
 
 export default function EventList({ isPublic = false, guestName }: EventListProps) {
   const houseCtx = useHouseContextSafe();
+  const houseId = useContext(HouseIdContext);
   const userName = houseCtx?.userName || guestName || "";
   const members = houseCtx?.members || [];
-  const { items: events, loading, add, update, remove } =
+  const { items: events, loading, error, add, update, remove } =
     useCollection<CasaEvent>("events");
   const [showCreate, setShowCreate] = useState(false);
   const [title, setTitle] = useState("");
@@ -138,7 +139,8 @@ export default function EventList({ isPublic = false, guestName }: EventListProp
 
   const handleShare = async () => {
     try {
-      const shareId = await getOrCreateShareId();
+      if (!houseId) throw new Error("Missing house id for event sharing");
+      const shareId = await getOrCreateShareId(houseId);
       const url = `${window.location.origin}/eventos/${shareId}`;
       await navigator.clipboard.writeText(url);
       setCopied(true);
@@ -161,10 +163,11 @@ export default function EventList({ isPublic = false, guestName }: EventListProp
     // Copy items from old event (reset done to false)
     // We need to get the items from the original event subcollection
     try {
-      const itemsSnap = await getDocs(collection(db, `events/${event.id}/items`));
+      if (!houseId) throw new Error("Missing house id for event clone");
+      const itemsSnap = await getDocs(collection(db, "houses", houseId, "events", event.id, "items"));
       const { addDoc, serverTimestamp } = await import("firebase/firestore");
       // Find the new event ID (it's the last active one with this title)
-      const eventsSnap = await getDocs(collection(db, "events"));
+      const eventsSnap = await getDocs(collection(db, "houses", houseId, "events"));
       const allEvents = eventsSnap.docs.map(d => ({ id: d.id, ...d.data() }));
       const newest = allEvents
         .filter((e) => (e as CasaEvent).title === `${event.title} (cópia)`)
@@ -173,7 +176,7 @@ export default function EventList({ isPublic = false, guestName }: EventListProp
       if (newest) {
         for (const itemDoc of itemsSnap.docs) {
           const data = itemDoc.data();
-          await addDoc(collection(db, `events/${newest.id}/items`), {
+          await addDoc(collection(db, "houses", houseId, "events", newest.id, "items"), {
             name: data.name,
             type: data.type,
             done: false,
@@ -201,6 +204,15 @@ export default function EventList({ isPublic = false, guestName }: EventListProp
     return (
       <div className="py-4 text-center text-pink-300 text-sm animate-pulse">
         A carregar eventos...
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="m-4 rounded-2xl border border-red-100 bg-red-50/80 p-4 text-center text-sm text-red-500">
+        Não foi possível aceder aos eventos no Firebase.
+        <p className="mt-1 break-all text-xs text-red-400">{error}</p>
       </div>
     );
   }

--- a/lib/share.ts
+++ b/lib/share.ts
@@ -12,21 +12,47 @@ function generateId(length = 12): string {
   return result;
 }
 
-export async function getOrCreateShareId(): Promise<string> {
-  const ref = doc(db, "config", "events-share");
-  const snap = await getDoc(ref);
+export interface EventShare {
+  shareId: string;
+  houseId: string;
+}
 
-  if (snap.exists() && snap.data().shareId) {
-    return snap.data().shareId as string;
+export async function getOrCreateShareId(houseId: string): Promise<string> {
+  if (!houseId) throw new Error("Missing house id for event sharing");
+
+  const houseShareRef = doc(db, "event_share_houses", houseId);
+  const houseShareSnap = await getDoc(houseShareRef);
+
+  if (houseShareSnap.exists() && houseShareSnap.data().shareId) {
+    return houseShareSnap.data().shareId as string;
   }
 
   const shareId = generateId();
-  await setDoc(ref, { shareId });
+  await setDoc(houseShareRef, { shareId, houseId });
+  await setDoc(doc(db, "event_shares", shareId), { shareId, houseId });
   return shareId;
 }
 
+export async function getEventShare(id: string): Promise<EventShare | null> {
+  const shareSnap = await getDoc(doc(db, "event_shares", id));
+  if (shareSnap.exists()) {
+    const data = shareSnap.data();
+    if (typeof data.houseId === "string" && data.houseId) {
+      return { shareId: id, houseId: data.houseId };
+    }
+  }
+
+  const legacySnap = await getDoc(doc(db, "config", "events-share"));
+  if (legacySnap.exists() && legacySnap.data().shareId === id) {
+    const legacyHouseId = legacySnap.data().houseId;
+    if (typeof legacyHouseId === "string" && legacyHouseId) {
+      return { shareId: id, houseId: legacyHouseId };
+    }
+  }
+
+  return null;
+}
+
 export async function validateShareId(id: string): Promise<boolean> {
-  const ref = doc(db, "config", "events-share");
-  const snap = await getDoc(ref);
-  return snap.exists() && snap.data().shareId === id;
+  return (await getEventShare(id)) !== null;
 }


### PR DESCRIPTION
### Motivation
- Public event share links were reading/writing root/legacy config docs and unscoped collections which prevented public pages from resolving the correct house-scoped Firestore data.
- The goal is to make public event pages reliably resolve a `houseId` for a share and only read/write under `houses/{houseId}/events`, and to surface Firebase access failures in the UI.

### Description
- Replace the legacy single `config/events-share` usage with a house-aware mapping by adding `getOrCreateShareId(houseId)` and `getEventShare(id)` and storing lookups in `event_shares` and `event_share_houses` in `lib/share.ts`.
- Resolve the share record on the public events page and inject the resolved `houseId` into `HouseIdContext` before rendering the event list in `app/eventos/[shareId]/page.tsx`.
- Update `components/EventList.tsx` to consume `HouseIdContext`, require a `houseId` for sharing/cloning, and change clone/read/write paths to use `houses/{houseId}/events/{eventId}/items` so all operations are house-scoped.
- Add an explicit error state in the events list to show Firebase access errors instead of silently failing.

### Testing
- Ran `npm run typecheck` and TypeScript checks completed successfully.
- Ran `npm run lint` and ESLint completed successfully with pre-existing warnings (no new errors).
- Ran `npm run build` and Next.js production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a43dfb72ae88329a6a9405176d69b44)