### PR TITLE
fix: omit undefined Firestore values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Swipe actions on list rows no longer propagate to dashboard tab navigation.
 - Failed habit creation remains visible and surfaces the Firestore error instead of
   silently closing the form.
+- Optional Firestore fields are omitted on create and deleted explicitly on update,
+  preventing writes from failing on unsupported `undefined` values.
 - Event sharing now opens the event that was selected rather than a house-wide view.
 
 ## [0.8.7] - 2026-05-05

--- a/components/HabitList.tsx
+++ b/components/HabitList.tsx
@@ -134,10 +134,10 @@ export default function HabitList() {
     const habitId = await add({
       name,
       emoji: newEmoji,
-      reminderTime: newTime || undefined,
       assignee: newAssignee,
-      days: newDays.length > 0 ? newDays : undefined,
       streak: 0,
+      ...(newTime ? { reminderTime: newTime } : {}),
+      ...(newDays.length > 0 ? { days: newDays } : {}),
     });
     if (!habitId) return;
 

--- a/lib/firestore-values.ts
+++ b/lib/firestore-values.ts
@@ -1,0 +1,7 @@
+export function omitUndefinedValues(
+  data: Record<string, unknown>
+): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(data).filter(([, value]) => value !== undefined)
+  );
+}

--- a/lib/hooks.ts
+++ b/lib/hooks.ts
@@ -12,8 +12,10 @@ import {
   doc,
   serverTimestamp,
   getDocs,
+  deleteField,
 } from "firebase/firestore";
 import { db } from "./firebase";
+import { omitUndefinedValues } from "./firestore-values";
 
 // Context for multi-tenant house scoping
 export const HouseIdContext = createContext<string | null>(null);
@@ -201,7 +203,7 @@ export function useCollection<T extends { id: string }>(
   const add = async (data: Omit<T, "id" | "createdAt">): Promise<string | null> => {
     try {
       const docRef = await addDoc(getCollectionRef(), {
-        ...data,
+        ...omitUndefinedValues(data as Record<string, unknown>),
         createdAt: serverTimestamp(),
       });
       setError(null);
@@ -218,7 +220,13 @@ export function useCollection<T extends { id: string }>(
       prev.map((item) => (item.id === id ? { ...item, ...data } : item))
     );
     try {
-      await updateDoc(getDocRef(id), data as Record<string, unknown>);
+      const firestoreUpdate = Object.fromEntries(
+        Object.entries(data).map(([key, value]) => [
+          key,
+          value === undefined ? deleteField() : value,
+        ])
+      );
+      await updateDoc(getDocRef(id), firestoreUpdate);
     } catch (e) {
       console.error("Update error:", e);
       await refetch();

--- a/tests/firestore-values.test.ts
+++ b/tests/firestore-values.test.ts
@@ -1,0 +1,17 @@
+import { omitUndefinedValues } from "@/lib/firestore-values";
+
+describe("omitUndefinedValues", () => {
+  it("removes optional undefined fields before Firestore creates", () => {
+    expect(omitUndefinedValues({
+      name: "Meditar",
+      reminderTime: undefined,
+      days: undefined,
+      streak: 0,
+    })).toEqual({ name: "Meditar", streak: 0 });
+  });
+
+  it("preserves valid falsey values", () => {
+    expect(omitUndefinedValues({ done: false, count: 0, note: "", nullable: null }))
+      .toEqual({ done: false, count: 0, note: "", nullable: null });
+  });
+});


### PR DESCRIPTION
## Summary

- omits optional `undefined` fields before Firestore document creation
- converts `undefined` updates into explicit Firestore field deletion
- builds new habit payloads without empty optional fields
- adds regression coverage for valid falsey values and undefined omission

## Root cause

Production reproduction of #117 showed `addDoc()` rejecting `reminderTime: undefined` and `days: undefined`. The UI error handling added in #130 correctly exposed the failure, but the underlying payload still needed correction.

## Validation

- production reproduction captured the exact Firestore error
- ESLint: zero warnings
- TypeScript: passed
- 52 tests: passed
- Next.js production build: passed

Closes #117
